### PR TITLE
Updating reference to NLog

### DIFF
--- a/src/NLog/NLog.csproj
+++ b/src/NLog/NLog.csproj
@@ -10,6 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="[4.1,5)" />
+    <PackageReference Include="NLog" Version="[4.0,5)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
We are getting build errors when updating to latest version of Nybus.NLog.
Since NLog are setting version name to 4.0.0.0 even though a higher version is installed Nybus.NLog need to include this version of NLog as lowest version.